### PR TITLE
fix: patterns ending with a star when subdirs

### DIFF
--- a/glob.go
+++ b/glob.go
@@ -69,20 +69,7 @@ func Glob(pattern string, opts ...Options) ([]string, error) {
 			return err
 		}
 
-		if !matcher.Match(path) {
-			return nil
-		}
-
-		if info.IsDir() {
-			// a direct match on a directory implies that all files inside match
-			filesInDir, err := filesInDirectory(fs, path)
-			if err != nil {
-				return err
-			}
-
-			matches = append(matches, filesInDir...)
-			return filepath.SkipDir
-		} else {
+		if matcher.Match(path) && !info.IsDir() {
 			matches = append(matches, path)
 		}
 
@@ -100,19 +87,4 @@ func compileOptions(opts []Options) Options {
 		}
 	}
 	return options
-}
-
-func filesInDirectory(fs afero.Fs, dir string) ([]string, error) {
-	var files []string
-
-	return files, afero.Walk(fs, dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			return nil
-		}
-		files = append(files, path)
-		return nil
-	})
 }

--- a/glob.go
+++ b/glob.go
@@ -64,15 +64,10 @@ func Glob(pattern string, opts ...Options) ([]string, error) {
 		return []string{}, nil
 	}
 
-	return matches, afero.Walk(fs, prefix, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
+	return matches, afero.Walk(fs, prefix, func(path string, info os.FileInfo, _ error) error {
 		if matcher.Match(path) && !info.IsDir() {
 			matches = append(matches, path)
 		}
-
 		return nil
 	})
 }

--- a/glob_test.go
+++ b/glob_test.go
@@ -115,6 +115,21 @@ func TestGlob(t *testing.T) {
 			"{a,b}/c",
 		}, matches)
 	})
+
+	t.Run("pattern ending with star and subdir", func(t *testing.T) {
+		matches, err := globInMemoryFs("a/*", []string{
+			"./a/1.txt",
+			"./a/2.txt",
+			"./a/3.txt",
+			"./a/b/4.txt",
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{
+			"a/1.txt",
+			"a/2.txt",
+			"a/3.txt",
+		}, matches)
+	})
 }
 
 func TestQuoteMeta(t *testing.T) {


### PR DESCRIPTION
given a structure like:

```
./a/1.txt
./a/2.txt
./a/3.txt
./a/b/4.txt
```

a pattern like `a/*` would wrongfully match `a/b/4.txt` as well, when it shouldn't.

In the end, it seems like we don't really need the second walk, although performance-wise it might be worse, but its not that relevant for this usecase IMHO 🤔 