### PR TITLE
refactor: separator et al

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,2 @@
+// Package fileglob provides a filesystem glob API.
+package fileglob

--- a/glob_test.go
+++ b/glob_test.go
@@ -228,6 +228,25 @@ func TestGlob(t *testing.T) { // nolint:funlen
 			"/a/c",
 		}, matches)
 	})
+
+	t.Run("pattern ending with star and subdir", func(t *testing.T) {
+		matches, err := Glob("a/*", WithFs(testFs(t, []string{
+			"./a/1.txt",
+			"./a/2.txt",
+			"./a/3.txt",
+			"./a/b/4.txt",
+		}, []string{
+			"a",
+			"a/b",
+		})))
+		require.NoError(t, err)
+		require.Equal(t, []string{
+			"a/1.txt",
+			"a/2.txt",
+			"a/3.txt",
+			"a/b/4.txt",
+		}, matches)
+	})
 }
 
 func TestQuoteMeta(t *testing.T) {

--- a/prefix.go
+++ b/prefix.go
@@ -11,12 +11,12 @@ import (
 
 // staticPrefix returns the file path inside the pattern up
 // to the first path element that contains a wildcard.
-func staticPrefix(pattern string, separator rune) (string, error) {
-	parts := strings.Split(pattern, string(separator))
+func staticPrefix(pattern string) (string, error) {
+	parts := strings.Split(pattern, string(filepath.Separator))
 
 	prefix := ""
-	if len(pattern) > 0 && rune(pattern[0]) == separator {
-		prefix = string(separator)
+	if len(pattern) > 0 && rune(pattern[0]) == filepath.Separator {
+		prefix = string(filepath.Separator)
 	}
 
 	for _, part := range parts {

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -1,7 +1,6 @@
 package fileglob
 
 import (
-	"path/filepath"
 	"testing"
 )
 
@@ -20,7 +19,7 @@ func TestStaticPrefix(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		prefix, err := staticPrefix(testCase.pattern, filepath.Separator)
+		prefix, err := staticPrefix(testCase.pattern)
 		if err != nil {
 			t.Errorf("staticPrefix: %v", err)
 		}


### PR DESCRIPTION
- removed the separator option as discussed in #4 
- added doc.go
- removed unused error from OptFunc
- added test from #2 