### PR TITLE
fix: file paths on windows conflict with the ast escape rune

### DIFF
--- a/glob_test.go
+++ b/glob_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestGlob(t *testing.T) { // nolint:funlen
+	t.Parallel()
 	t.Run("real", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("*_test.go")
 		require.NoError(t, err)
 		require.Equal(t, []string{
@@ -21,6 +23,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("./a/*/*", WithFs(testFs(t, []string{
 			"./c/file1.txt",
 			"./a/nope/file1.txt",
@@ -39,6 +42,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("single file", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("a/b/*", WithFs(testFs(t, []string{
 			"./c/file1.txt",
 			"./a/nope/file1.txt",
@@ -49,6 +53,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("super asterisk", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("a/**/*", WithFs(testFs(t, []string{
 			"./a/nope.txt",
 			"./a/d/file1.txt",
@@ -64,6 +69,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("alternative matchers", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("a/{b,d}/file.txt", WithFs(testFs(t, []string{
 			"a/b/file.txt",
 			"a/c/file.txt",
@@ -77,6 +83,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("character list and range matchers", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("[!bc]/[a-z]/file[01].txt", WithFs(testFs(t, []string{
 			"a/b/file0.txt",
 			"a/c/file1.txt",
@@ -93,6 +100,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("nested matchers", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("{a,[0-9]b}.txt", WithFs(testFs(t, []string{
 			"a.txt",
 			"b.txt",
@@ -107,6 +115,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("single symbol wildcards", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("a?.txt", WithFs(testFs(t, []string{
 			"a.txt",
 			"a1.txt",
@@ -120,6 +129,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("direct match", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("a/b/c", WithFs(testFs(t, []string{
 			"./a/nope.txt",
 			"./a/b/c",
@@ -129,6 +139,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("direct match wildcard", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob(QuoteMeta("a/b/c{a"), WithFs(testFs(t, []string{
 			"./a/nope.txt",
 			"a/b/c{a",
@@ -138,6 +149,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("direct no match", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("a/b/d", WithFs(testFs(t, []string{
 			"./a/nope.txt",
 			"./a/b/dc",
@@ -148,6 +160,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("escaped direct no match", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("a/\\{b\\}", WithFs(testFs(t, nil, nil)))
 		require.EqualError(t, err, "matching \"a/{b}\": file does not exist")
 		require.True(t, errors.Is(err, os.ErrNotExist))
@@ -155,6 +168,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("direct no match escaped wildcards", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob(QuoteMeta("a/b/c{a"), WithFs(testFs(t, []string{
 			"./a/nope.txt",
 			"./a/b/dc",
@@ -164,6 +178,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("no matches", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("z/*", WithFs(testFs(t, []string{
 			"./a/nope.txt",
 		}, nil)))
@@ -172,12 +187,14 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("empty folder", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("a*", WithFs(testFs(t, nil, nil)))
 		require.NoError(t, err)
 		require.Empty(t, matches)
 	})
 
 	t.Run("escaped asterisk", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("a/\\*/b", WithFs(testFs(t, []string{
 			"a/a/b",
 			"a/*/b",
@@ -190,6 +207,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("escaped curly braces", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("\\{a,b\\}/c", WithFs(testFs(t, []string{
 			"a/c",
 			"b/c",
@@ -202,12 +220,14 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("invalid pattern", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("[*", WithFs(testFs(t, nil, nil)))
 		require.EqualError(t, err, "compile glob pattern: unexpected end of input")
 		require.Empty(t, matches)
 	})
 
 	t.Run("prefix is a file", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("ab/c/*", WithFs(testFs(t, []string{
 			"ab/c",
 			"ab/d",
@@ -218,6 +238,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("match files in directories", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("/a/{b,c}", WithFs(testFs(t, []string{
 			"/a/b/d",
 			"/a/b/e/f",
@@ -232,6 +253,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("match directories directly", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("/a/{b,c}", MatchDirectories(true), WithFs(testFs(t, []string{
 			"/a/b/d",
 			"/a/b/e/f",
@@ -245,6 +267,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("match empty directory", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("/a/{b,c}", MatchDirectories(true), WithFs(testFs(t, []string{
 			"/a/b",
 		}, []string{
@@ -258,6 +281,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 	})
 
 	t.Run("pattern ending with star and subdir", func(t *testing.T) {
+		t.Parallel()
 		matches, err := Glob("a/*", WithFs(testFs(t, []string{
 			"./a/1.txt",
 			"./a/2.txt",
@@ -278,6 +302,7 @@ func TestGlob(t *testing.T) { // nolint:funlen
 }
 
 func TestQuoteMeta(t *testing.T) {
+	t.Parallel()
 	matches, err := Glob(QuoteMeta("{a,b}/c"), WithFs(testFs(t, []string{
 		"a/c",
 		"b/c",

--- a/prefix.go
+++ b/prefix.go
@@ -2,7 +2,6 @@ package fileglob
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/gobwas/glob/syntax/ast"
@@ -59,13 +58,10 @@ func staticText(node *ast.Node) (text string, ok bool) {
 // staticPrefix returns the file path inside the pattern up
 // to the first path element that contains a wildcard.
 func staticPrefix(pattern string) (string, error) {
-	parts := strings.Split(pattern, string(filepath.Separator))
+	parts := strings.Split(pattern, stringSeparator)
 
-	prefix := ""
-	if len(pattern) > 0 && rune(pattern[0]) == filepath.Separator {
-		prefix = string(filepath.Separator)
-	}
-
+	// nolint:prealloc
+	var prefixPath []string
 	for _, part := range parts {
 		if part == "" {
 			continue
@@ -81,7 +77,11 @@ func staticPrefix(pattern string) (string, error) {
 			break
 		}
 
-		prefix = filepath.Join(prefix, staticPart)
+		prefixPath = append(prefixPath, staticPart)
+	}
+	prefix := strings.Join(prefixPath, stringSeparator)
+	if len(pattern) > 0 && rune(pattern[0]) == runeSeparator && !strings.HasPrefix(prefix, stringSeparator) {
+		prefix = stringSeparator + prefix
 	}
 
 	if prefix == "" {

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestStaticPrefix(t *testing.T) {
+	t.Parallel()
 	var testCases = []struct {
 		pattern string
 		prefix  string
@@ -22,6 +23,7 @@ func TestStaticPrefix(t *testing.T) {
 		{"./", "."},
 		{"fo\\*o/bar/b*z", "fo*o/bar"},
 		{"/\\{foo\\}/bar", "/{foo}/bar"},
+		{"C:/Path/To/Some/File", "C:/Path/To/Some/File"},
 	}
 
 	for _, testCase := range testCases {
@@ -32,6 +34,7 @@ func TestStaticPrefix(t *testing.T) {
 }
 
 func TestContainsMatchers(t *testing.T) {
+	t.Parallel()
 	var testCases = []struct {
 		pattern          string
 		containsMatchers bool
@@ -57,6 +60,7 @@ func TestContainsMatchers(t *testing.T) {
 }
 
 func TestValidPattern(t *testing.T) {
+	t.Parallel()
 	var testCases = []struct {
 		pattern string
 		valid   bool


### PR DESCRIPTION
fix: file paths on windows conflict with the ast escape rune so we need to keep paths in the linux style

Related-To: https://github.com/goreleaser/goreleaser/discussions/1935

```
PS C:\Users\digit\projects\fileglob> go test -v ./...
=== RUN   TestGlob
=== RUN   TestGlob/real
=== RUN   TestGlob/simple
=== RUN   TestGlob/single_file
=== RUN   TestGlob/super_asterisk
=== RUN   TestGlob/alternative_matchers
=== RUN   TestGlob/character_list_and_range_matchers
=== RUN   TestGlob/nested_matchers
=== RUN   TestGlob/single_symbol_wildcards
=== RUN   TestGlob/direct_match
=== RUN   TestGlob/direct_match_wildcard
=== RUN   TestGlob/direct_no_match
=== RUN   TestGlob/escaped_direct_no_match
=== RUN   TestGlob/direct_no_match_escaped_wildcards
=== RUN   TestGlob/no_matches
=== RUN   TestGlob/empty_folder
=== RUN   TestGlob/escaped_asterisk
=== RUN   TestGlob/escaped_curly_braces
=== RUN   TestGlob/invalid_pattern
=== RUN   TestGlob/prefix_is_a_file
=== RUN   TestGlob/match_files_in_directories
=== RUN   TestGlob/match_directories_directly
=== RUN   TestGlob/match_empty_directory
=== RUN   TestGlob/pattern_ending_with_star_and_subdir
--- PASS: TestGlob (0.01s)
    --- PASS: TestGlob/real (0.00s)
    --- PASS: TestGlob/simple (0.00s)
    --- PASS: TestGlob/single_file (0.00s)
    --- PASS: TestGlob/super_asterisk (0.00s)
    --- PASS: TestGlob/alternative_matchers (0.00s)
    --- PASS: TestGlob/character_list_and_range_matchers (0.00s)
    --- PASS: TestGlob/nested_matchers (0.00s)
    --- PASS: TestGlob/single_symbol_wildcards (0.00s)
    --- PASS: TestGlob/direct_match (0.00s)
    --- PASS: TestGlob/direct_match_wildcard (0.00s)
    --- PASS: TestGlob/direct_no_match (0.00s)
    --- PASS: TestGlob/escaped_direct_no_match (0.00s)
    --- PASS: TestGlob/direct_no_match_escaped_wildcards (0.00s)
    --- PASS: TestGlob/no_matches (0.00s)
    --- PASS: TestGlob/empty_folder (0.00s)
    --- PASS: TestGlob/escaped_asterisk (0.00s)
    --- PASS: TestGlob/escaped_curly_braces (0.00s)
    --- PASS: TestGlob/invalid_pattern (0.00s)
    --- PASS: TestGlob/prefix_is_a_file (0.00s)
    --- PASS: TestGlob/match_files_in_directories (0.00s)
    --- PASS: TestGlob/match_directories_directly (0.00s)
    --- PASS: TestGlob/match_empty_directory (0.00s)
    --- PASS: TestGlob/pattern_ending_with_star_and_subdir (0.00s)
=== RUN   TestQuoteMeta
--- PASS: TestQuoteMeta (0.00s)
=== RUN   TestStaticPrefix
--- PASS: TestStaticPrefix (0.00s)
=== RUN   TestContainsMatchers
--- PASS: TestContainsMatchers (0.00s)
=== RUN   TestValidPattern
--- PASS: TestValidPattern (0.00s)
PASS
ok      github.com/goreleaser/fileglob  0.043s
```